### PR TITLE
docs: improve README with project structure, commands, and conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ Created by: **Oleksii Ivashchenko** [Linkedin](https://www.linkedin.com/in/oivas
 
 This project is a boilerplate for Playwright tests written in Typescript. It includes sample tests, configured to run tests in three different browsers, and has built-in linting and formatting tools (eslint and prettier) with Git hooks (husky). Additionally, the project is set up for Github Actions to run tests in a container.
 
+## Project Structure
+
+Two independent test suites with separate Playwright configs:
+
+```
+tests/*.spec.ts         → playwright.config.ts       (chromium + firefox + webkit)
+tests-api/*.test.ts     → playwright.api.config.ts   (request fixture, no browser)
+
+lib/pages/              → page objects (extend BasePage)
+lib/components/         → reusable Locator wrappers
+lib/fixtures.ts         → test extended with loginPage / inventoryPage fixtures
+lib/types/              → shared TypeScript types
+constants.ts            → UI base URL + test user credentials
+constants-api-tests.ts  → API base URL
+```
+
 ## Setup
 
 To use this project, download, clone or fork the repository.
@@ -20,19 +36,33 @@ This project requires github secret to be configure.
 
 Set up USER_PASS variable (see default value in the `.env.example` file) in the `/settings/secrets/actions` of your repository.
 
-## Usage
-
-To run the sample tests in all three browsers (Chromium, Firefox, and Webkit), use the following command:
+## Commands
 
 ```bash
-yarn test
+yarn test        # UI tests — chromium, firefox, webkit
+yarn test:api    # API tests
+yarn test:ui     # open Playwright UI mode
+yarn test:ci     # CI run with sharding
+yarn lint        # lint check
+yarn lint-fix    # auto-fix lint issues
 ```
+
+## Key Conventions
+
+- **Selectors**: always `getByTestId()` — `testIdAttribute` is set to `data-test` in `playwright.config.ts`
+- **Test imports**: `test` and `expect` from `@fixtures`, not from `@playwright/test`
+- **Page objects**: extend `BasePage`; locators `private readonly`; methods `async`
+- **Anti-patterns**: no `page.waitForTimeout()`, no CSS class selectors, no `test.only` in commits
+
+For full detail see `CLAUDE.md` (Claude Code users) or `.codex/skills/playwright-test-writing/SKILL.md`.
 
 ## AI-Assisted Test Authoring (Skill)
 
 This repo includes guidance for a skill to help modern AI coding tools generate Playwright tests that follow local conventions.
 
-**Skill location (global Codex skills):** `/.codex/skills/playwright-test-authoring/SKILL.md`
+**For Claude Code / Claude.ai users:** `CLAUDE.md` at the repo root is loaded automatically and provides always-on context — commands, conventions, file placement rules, and anti-patterns.
+
+**Skill location:** `.codex/skills/playwright-test-writing/SKILL.md`
 
 What the skill encodes:
 
@@ -45,7 +75,7 @@ What the skill encodes:
 ### How to use it with AI coding tools
 
 1. Open the repo in your AI tool (Codex Desktop, ChatGPT with repo access, Cursor, Windsurf, VS Code Copilot Chat, etc.).
-2. Point the tool to `/.codex/skills/playwright-test-authoring/SKILL.md` and its references directory.
+2. Point the tool to `.codex/skills/playwright-test-writing/SKILL.md` and its references directory.
 3. Ask it to create tests using the existing patterns.
 
 ### Example prompts
@@ -74,7 +104,9 @@ This project includes Git hooks using husky. When you commit changes, husky will
 
 ## Github Actions
 
-This project is set up for Github Actions to run tests in a container. The Github Actions workflow is defined in the `.github/workflows/playwright.yml` file. The workflow will run the tests in browsers defined in `playwright.config.ts`.
+This project is set up for Github Actions to run tests in a container. The workflow is defined in `.github/workflows/playwright.yml`.
+
+It uses **path-based filtering** — only the affected suite runs when you push (e2e changes trigger the UI job, API changes trigger the API job). E2E tests run with **sharding** across multiple workers for faster CI.
 
 ## API tests
 


### PR DESCRIPTION
## Summary

- **Project Structure section** — maps both test suites to their configs (`playwright.config.ts` / `playwright.api.config.ts`) and documents the `lib/` layout
- **Commands section** — documents all scripts (`test:api`, `test:ui`, `test:ci`, `lint`, `lint-fix`), previously only `yarn test` was mentioned
- **Key Conventions section** — selectors, test imports (`@fixtures`), page object rules, anti-patterns
- **Fixed wrong AI skill path** — `playwright-test-authoring` → `playwright-test-writing`
- **CLAUDE.md mention** — notes it as the always-loaded quick-reference for Claude Code / Claude.ai users
- **GitHub Actions** — brief note on path-based filtering and sharding

## Test plan

- [ ] README renders correctly on GitHub with no broken links or malformed markdown
- [ ] All referenced paths exist in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)